### PR TITLE
BKscan fixed "x11: failed to open display" issue

### DIFF
--- a/FreeRDP_scanner.patch
+++ b/FreeRDP_scanner.patch
@@ -838,11 +838,16 @@ diff '--exclude=build' -Naur FreeRDP_original/libfreerdp/core/nego.c FreeRDP_sca
 diff '--exclude=build' -Naur FreeRDP_original/libfreerdp/core/rdp.c FreeRDP_scanner/libfreerdp/core/rdp.c
 --- FreeRDP_original/libfreerdp/core/rdp.c	2019-06-05 08:59:36.201112153 +0100
 +++ FreeRDP_scanner/libfreerdp/core/rdp.c	2019-06-10 09:53:02.972558646 +0100
-@@ -402,6 +402,13 @@
+@@ -402,6 +402,18 @@
  		EventArgsInit(&e, "freerdp");
  		e.code = 0;
  		PubSub_OnTerminate(context->pubSub, context, &e);
 +		
++
++               if (rdp->errorInfo == ERRINFO_SERVER_INSUFFICIENT_PRIVILEGES) {
++                       printf("[!] User is not in Remote Desktop Users Group.\n"); 
++                       exit(0);
++               }
 +
 +		if (rdp->settings->cve_2019_0708) {
 +			printf("[!] Target is VULNERABLE!!!\n");

--- a/bkscan.sh
+++ b/bkscan.sh
@@ -92,5 +92,5 @@ else
       --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
       --volume="$HOME/.Xauthority:$HOME/.Xauthority" \
       bkscan \
-      xfreerdp /cve-2019-0708 /cert-ignore /v:${TARGET_IP}:${TARGET_PORT} ${DEBUG}
+      xfreerdp /cve-2019-0708 /cert-ignore /v:${TARGET_IP}:${TARGET_PORT} -sec-nla /u:"" ${DEBUG}
 fi

--- a/bkscan.sh
+++ b/bkscan.sh
@@ -68,14 +68,7 @@ then
     docker run -it --rm --privileged \
       --user=$USER \
       --env="DISPLAY" \
-      --workdir="/home/$USER" \
-      --volume="/home/$USER:/home/$USER" \
-      --volume="/etc/group:/etc/group:ro" \
-      --volume="/etc/passwd:/etc/passwd:ro" \
-      --volume="/etc/shadow:/etc/shadow:ro" \
-      --volume="/etc/sudoers.d:/etc/sudoers.d:ro" \
       --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
-      --volume="$HOME/.Xauthority:$HOME/.Xauthority" \
       bkscan \
       xfreerdp /cve-2019-0708 /cert-ignore /v:${TARGET_IP}:${TARGET_PORT} /u:${RDP_USER} /p:${RDP_PASSWORD} ${DEBUG}
 else
@@ -83,14 +76,7 @@ else
     docker run -it --rm --privileged \
       --user=$USER \
       --env="DISPLAY" \
-      --workdir="/home/$USER" \
-      --volume="/home/$USER:/home/$USER" \
-      --volume="/etc/group:/etc/group:ro" \
-      --volume="/etc/passwd:/etc/passwd:ro" \
-      --volume="/etc/shadow:/etc/shadow:ro" \
-      --volume="/etc/sudoers.d:/etc/sudoers.d:ro" \
       --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
-      --volume="$HOME/.Xauthority:$HOME/.Xauthority" \
       bkscan \
       xfreerdp /cve-2019-0708 /cert-ignore /v:${TARGET_IP}:${TARGET_PORT} -sec-nla /u:"" ${DEBUG}
 fi

--- a/bkscan.sh
+++ b/bkscan.sh
@@ -66,15 +66,31 @@ if [[ ! -z $RDP_USER && ! -z $RDP_PASSWORD ]]
 then
     echo [+] Using provided credentials, will support NLA
     docker run -it --rm --privileged \
-      -e DISPLAY=$DISPLAY \
-      -v /tmp/.X11-unix:/tmp/.X11-unix \
+      --user=$USER \
+      --env="DISPLAY" \
+      --workdir="/home/$USER" \
+      --volume="/home/$USER:/home/$USER" \
+      --volume="/etc/group:/etc/group:ro" \
+      --volume="/etc/passwd:/etc/passwd:ro" \
+      --volume="/etc/shadow:/etc/shadow:ro" \
+      --volume="/etc/sudoers.d:/etc/sudoers.d:ro" \
+      --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
+      --volume="$HOME/.Xauthority:$HOME/.Xauthority" \
       bkscan \
       xfreerdp /cve-2019-0708 /cert-ignore /v:${TARGET_IP}:${TARGET_PORT} /u:${RDP_USER} /p:${RDP_PASSWORD} ${DEBUG}
 else
     echo [+] No credential provided, won\'t support NLA
     docker run -it --rm --privileged \
-      -e DISPLAY=$DISPLAY \
-      -v /tmp/.X11-unix:/tmp/.X11-unix \
+      --user=$USER \
+      --env="DISPLAY" \
+      --workdir="/home/$USER" \
+      --volume="/home/$USER:/home/$USER" \
+      --volume="/etc/group:/etc/group:ro" \
+      --volume="/etc/passwd:/etc/passwd:ro" \
+      --volume="/etc/shadow:/etc/shadow:ro" \
+      --volume="/etc/sudoers.d:/etc/sudoers.d:ro" \
+      --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
+      --volume="$HOME/.Xauthority:$HOME/.Xauthority" \
       bkscan \
       xfreerdp /cve-2019-0708 /cert-ignore /v:${TARGET_IP}:${TARGET_PORT} ${DEBUG}
 fi


### PR DESCRIPTION
### 1) Issue with x11:
```
$ sudo ./bkscan.sh -t 192.168.119.137
[+] Targeting 192.168.119.137:3389...
[+] No credential provided, won't support NLA
[07:58:35:866] [1:1] [ERROR][com.freerdp.client.x11] - failed to open display: :0
[07:58:35:866] [1:1] [ERROR][com.freerdp.client.x11] - Please check that the $DISPLAY environment variable is properly set.
```
Fixed with information [from here](http://wiki.ros.org/docker/Tutorials/GUI#The_safer_way)

Working good now:
![image](https://user-images.githubusercontent.com/10115306/59506456-f0fcd300-8eb0-11e9-9e93-1e1888040902.png)

If you are using ssh to kali where is BKscan so you need to redefine $DISPLAY variable:
`export DISPLAY=:1`

### 2) Issue with xfreerdp asking username/password on hosts without NLA
Also added  `xfreerdp -sec-nla /u:""` flag so scan now works on hosts without NLA, it is not asking username\password any more.

![image](https://user-images.githubusercontent.com/10115306/59506221-5f8d6100-8eb0-11e9-9182-259fad22874d.png)

If username\pass not provided, but NLA is enabled on host:
![image](https://user-images.githubusercontent.com/10115306/59506309-92375980-8eb0-11e9-87f6-07937643abf0.png)

In `--debug` mode it is clear:
![image](https://user-images.githubusercontent.com/10115306/59506407-c6127f00-8eb0-11e9-9dc9-23e38a5d3da8.png)

